### PR TITLE
feat: Enabled to download and attached pdf with naming format

### DIFF
--- a/pdf_on_submit/attach_pdf.py
+++ b/pdf_on_submit/attach_pdf.py
@@ -21,7 +21,7 @@ from frappe import _
 from frappe import publish_progress
 from frappe.core.doctype.file.file import create_new_folder
 from frappe.utils.file_manager import save_file
-from frappe.model.naming import _field_autoname, set_name_by_naming_series, _prompt_autoname, _format_autoname, make_autoname
+from frappe.model.naming import _format_autoname
 
 
 
@@ -137,14 +137,7 @@ def set_name_from_naming_options(autoname, doc):
 
     _autoname = autoname.lower()
 
-    if _autoname.startswith("field:"):
-        name = _field_autoname(autoname, doc)
-    elif _autoname.startswith("naming_series:"):
-        set_name_by_naming_series(doc)
-    elif _autoname.startswith("prompt"):
-        _prompt_autoname(autoname, doc)
-    elif _autoname.startswith("format:"):
+    if _autoname.startswith("format:"):
         name = _format_autoname(autoname, doc)
-    elif "#" in autoname:
-        name = make_autoname(autoname, doc=doc)
-    return name
+        return name
+    return doc.name

--- a/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+++ b/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
@@ -18,7 +18,7 @@
    "reqd": 1
   },
   {
-   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}-{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>",
+   "description": "Naming Options:\n<ol><li><b>format:EXAMPLE-{MM}-{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>",
    "fieldname": "autoname",
    "fieldtype": "Data",
    "label": "Auto Name"
@@ -26,7 +26,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-06-10 07:09:49.504305",
+ "modified": "2022-06-10 11:17:55.864291",
  "modified_by": "Administrator",
  "module": "PDF on Submit",
  "name": "Enabled DocType",

--- a/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+++ b/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
@@ -5,7 +5,8 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "document_type"
+  "document_type",
+  "autoname"
  ],
  "fields": [
   {
@@ -15,11 +16,17 @@
    "label": "Document Type",
    "options": "DocType",
    "reqd": 1
+  },
+  {
+   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}-{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>",
+   "fieldname": "autoname",
+   "fieldtype": "Data",
+   "label": "Auto Name"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-01-13 15:41:24.310478",
+ "modified": "2022-06-10 07:09:49.504305",
  "modified_by": "Administrator",
  "module": "PDF on Submit",
  "name": "Enabled DocType",


### PR DESCRIPTION
Change log:
1. Added autoname field in enabled_doctype in PDF on submit settings.
![image-20220609-131350](https://user-images.githubusercontent.com/6947417/172997205-56cdbc14-c829-43a9-9561-c5fe90528da6.png)

POC:
![Peek 2022-06-10 10-53](https://user-images.githubusercontent.com/6947417/172997290-347d3b92-0643-4a54-878e-97b5aa63f8fd.gif)

Limitation: naming format does not accept the date field yet. 