### PR TITLE
feat: add support for new print format builder

### DIFF
--- a/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+++ b/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
@@ -6,6 +6,8 @@
  "engine": "InnoDB",
  "field_order": [
   "document_type",
+  "print_format",
+  "letter_head",
   "auto_name"
  ],
  "fields": [
@@ -22,11 +24,25 @@
    "fieldname": "auto_name",
    "fieldtype": "Data",
    "label": "Auto Name"
+  },
+  {
+   "fieldname": "print_format",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Print Format",
+   "options": "Print Format"
+  },
+  {
+   "fieldname": "letter_head",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Letter Head",
+   "options": "Letter Head"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-06-10 15:06:47.854929",
+ "modified": "2022-11-23 19:10:49.683993",
  "modified_by": "Administrator",
  "module": "PDF on Submit",
  "name": "Enabled DocType",
@@ -35,5 +51,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
@@ -1,8 +1,14 @@
 // Copyright (c) 2019, Raffael Meyer and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('PDF on Submit Settings', {
-	refresh: function(frm) {
-
-	}
+frappe.ui.form.on("PDF on Submit Settings", {
+	refresh(frm) {
+		frm.set_query("print_format", "enabled_for", function(doc, cdt, cdn) {
+			return {
+				filters: {
+					doc_type: locals[cdt][cdn].document_type,
+				},
+			};
+		});
+	},
 });


### PR DESCRIPTION
- Add options to specify **Print Format** and **Letter Head** in **PDF on Submit Settings** (because the new print format builder wants to know these and doesn't pull default values itself)
- **Letter Head** only works with the new print format builder for now. If and when https://github.com/frappe/frappe/pull/18989 gets merged, we can add support for old print formats as well.
