### PR TITLE
fix: Enqueue PDF creation after commit to avoid stale doc values

### DIFF
--- a/pdf_on_submit/attach_pdf.py
+++ b/pdf_on_submit/attach_pdf.py
@@ -46,6 +46,7 @@ def attach_pdf(doc, event=None):
 			or frappe.flags.in_test
 			or frappe.conf.developer_mode
 		),
+		enqueue_after_commit=True,
 		**args,
 	)
 


### PR DESCRIPTION
- In prod setups,the enqueued job starts running before the commit after submission
- This leads to `frappe.get_doc` in printview.py reading stale values from the db (docstatus: 0 even after submission)
- Which in turns generated PDFs with "Draft" as the heading and attaches them to submitted documents (if this setting is enabled in **Print Settings**)
- **Solution:** Make sure the job is only enqueued after commit for fresh `doc` values