### PR TITLE
feat: add filters to enabled doctype

### DIFF
--- a/pdf_on_submit/attach_pdf.py
+++ b/pdf_on_submit/attach_pdf.py
@@ -15,25 +15,28 @@ from frappe.utils.weasyprint import PrintFormatGenerator
 
 def attach_pdf(doc, event=None):
 	settings = frappe.get_single("PDF on Submit Settings")
+	enabled_doctypes = settings.get("enabled_for", {"document_type": doc.doctype})
 
-	if enabled_doctypes := settings.get("enabled_for", {"document_type": doc.doctype}):
-		enabled_doctype = enabled_doctypes[0]
-	else:
+	if not enabled_doctypes:
 		return
 
-	if enabled_doctype.filters:
-		filters = json.loads(enabled_doctype.filters)
+	for dt_settings in enabled_doctypes:
+		process_enabled_doctype(doc, dt_settings, settings.create_pdf_in_background)
+
+
+def process_enabled_doctype(doc, settings, in_background):
+	if settings.filters:
+		filters = json.loads(settings.filters)
 		if filters:
 			condition_met = evaluate_filters(doc, filters)
 			if not condition_met:
 				return
 
-	auto_name = enabled_doctype.auto_name
+	auto_name = settings.auto_name
 	print_format = (
-		enabled_doctype.print_format or doc.meta.default_print_format or "Standard"
+		settings.print_format or doc.meta.default_print_format or "Standard"
 	)
-	letter_head = enabled_doctype.letter_head or None
-
+	letter_head = settings.letter_head or None
 	fallback_language = (
 		frappe.db.get_single_value("System Settings", "language") or "en"
 	)
@@ -42,7 +45,7 @@ def attach_pdf(doc, event=None):
 		"name": doc.name,
 		"title": doc.get_title() if doc.meta.title_field else None,
 		"lang": getattr(doc, "language", fallback_language),
-		"show_progress": not settings.create_pdf_in_background,
+		"show_progress": not in_background,
 		"auto_name": auto_name,
 		"print_format": print_format,
 		"letter_head": letter_head,
@@ -52,7 +55,7 @@ def attach_pdf(doc, event=None):
 		method=execute,
 		timeout=30,
 		now=bool(
-			not settings.create_pdf_in_background
+			not in_background
 			or frappe.flags.in_test
 			or frappe.conf.developer_mode
 		),

--- a/pdf_on_submit/attach_pdf.py
+++ b/pdf_on_submit/attach_pdf.py
@@ -1,12 +1,15 @@
 # Copyright (c) 2019, Raffael Meyer and contributors
 # For license information, please see license.txt
 
+import json
+
 import frappe
 from frappe import _
 from frappe.core.api.file import create_new_folder
 from frappe.model.naming import _format_autoname
 from frappe.realtime import publish_realtime
 from frappe.translate import print_language
+from frappe.utils.data import evaluate_filters
 from frappe.utils.weasyprint import PrintFormatGenerator
 
 
@@ -17,6 +20,13 @@ def attach_pdf(doc, event=None):
 		enabled_doctype = enabled_doctypes[0]
 	else:
 		return
+
+	if enabled_doctype.filters:
+		filters = json.loads(enabled_doctype.filters)
+		if filters:
+			condition_met = evaluate_filters(doc, filters)
+			if not condition_met:
+				return
 
 	auto_name = enabled_doctype.auto_name
 	print_format = (

--- a/pdf_on_submit/locale/de.po
+++ b/pdf_on_submit/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PDF on Submit VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2024-07-20 23:34+0053\n"
+"POT-Creation-Date: 2025-02-07 19:25+0053\n"
 "PO-Revision-Date: 2024-07-20 23:34+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -17,51 +17,65 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 
 #. Name of a role
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "Accounts Manager"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'PDF on Submit Settings'
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "Active"
 msgstr "Aktiv"
 
 #. Label of a Data field in DocType 'Enabled DocType'
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid "Auto Name"
 msgstr "Schema für Dateiname"
 
 #. Label of a Check field in DocType 'PDF on Submit Settings'
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "Create PDF In Background"
 msgstr "PDF im Hintergrund erstellen"
 
-#: attach_pdf.py:88
+#: pdf_on_submit/attach_pdf.py:85
 msgid "Creating PDF ..."
 msgstr "Erstelle PDF ..."
 
 #. Label of a Link field in DocType 'Enabled DocType'
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid "Document Type"
 msgstr "Dokumenttyp"
 
+#. Label of a Button field in DocType 'Enabled DocType'
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+msgid "Edit Filters"
+msgstr "Filter bearbeiten"
+
 #. Name of a DocType
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid "Enabled DocType"
 msgstr "Aktivierter Dokumenttyp"
 
 #. Label of a Table field in DocType 'PDF on Submit Settings'
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "Enabled For"
 msgstr "Aktiviert für"
 
+#: pdf_on_submit/attach_pdf.py:112
+msgid "Failed to attach XML to PDF for Sales Invoice {0}"
+msgstr "Fehler beim Anhängen von XML an PDF für Verkaufsrechnung {0}"
+
+#. Label of a Code field in DocType 'Enabled DocType'
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+msgid "Filters"
+msgstr "Filter"
+
 #. Label of a Link field in DocType 'Enabled DocType'
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid "Letter Head"
 msgstr "Briefkopf"
 
 #. Description of the 'Auto Name' (Data) field in DocType 'Enabled DocType'
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid ""
 "Naming Options:\n"
 "<ol><li><b>format:EXAMPLE-{MM}-{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>"
@@ -69,18 +83,28 @@ msgstr ""
 "Optionen:\n"
 "<ol><li><b>format:BEISPIEL-{MM}-{feldname1}-{feldname2}-{#####}</b> - Ersetzt alle in geschweiften Klammern stehenden Wörter (Feldnamen, Datumsangaben (DD, MM, YY), Nummernkreise) durch ihren Wert. Außerhalb der geschweiften Klammern können beliebige Zeichen verwendet werden.</li></ol>"
 
+#. Description of the 'Edit Filters' (Button) field in DocType 'Enabled
+#. DocType'
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+msgid "Optional: create PDF only if the submitted document matches these filters."
+msgstr "Optional: PDF nur erstellen, wenn das gebuchte Dokument diesen Filtern entspricht."
+
 #. Name of a DocType
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "PDF on Submit Settings"
 msgstr "PDF-on-Submit-Einstellungen"
 
 #. Label of a Link field in DocType 'Enabled DocType'
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid "Print Format"
 msgstr ""
 
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js:22
+msgid "Set Filters"
+msgstr "Filter setzen"
+
 #. Name of a role
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "System Manager"
 msgstr ""
 

--- a/pdf_on_submit/locale/main.pot
+++ b/pdf_on_submit/locale/main.pot
@@ -1,14 +1,14 @@
 # Translations template for PDF on Submit.
-# Copyright (C) 2024 ALYF GmbH
+# Copyright (C) 2025 ALYF GmbH
 # This file is distributed under the same license as the PDF on Submit project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PDF on Submit VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2024-07-21 00:05+0053\n"
-"PO-Revision-Date: 2024-07-21 00:05+0053\n"
+"POT-Creation-Date: 2025-02-07 19:25+0053\n"
+"PO-Revision-Date: 2025-02-07 19:25+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -17,68 +17,92 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 
 #. Name of a role
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "Accounts Manager"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'PDF on Submit Settings'
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "Active"
 msgstr ""
 
 #. Label of a Data field in DocType 'Enabled DocType'
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid "Auto Name"
 msgstr ""
 
 #. Label of a Check field in DocType 'PDF on Submit Settings'
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "Create PDF In Background"
 msgstr ""
 
-#: attach_pdf.py:74
+#: pdf_on_submit/attach_pdf.py:85
 msgid "Creating PDF ..."
 msgstr ""
 
 #. Label of a Link field in DocType 'Enabled DocType'
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid "Document Type"
 msgstr ""
 
+#. Label of a Button field in DocType 'Enabled DocType'
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+msgid "Edit Filters"
+msgstr ""
+
 #. Name of a DocType
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid "Enabled DocType"
 msgstr ""
 
 #. Label of a Table field in DocType 'PDF on Submit Settings'
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "Enabled For"
 msgstr ""
 
+#: pdf_on_submit/attach_pdf.py:112
+msgid "Failed to attach XML to PDF for Sales Invoice {0}"
+msgstr ""
+
+#. Label of a Code field in DocType 'Enabled DocType'
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+msgid "Filters"
+msgstr ""
+
 #. Label of a Link field in DocType 'Enabled DocType'
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid "Letter Head"
 msgstr ""
 
 #. Description of the 'Auto Name' (Data) field in DocType 'Enabled DocType'
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid ""
 "Naming Options:\n"
 "<ol><li><b>format:EXAMPLE-{MM}-{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>"
 msgstr ""
 
+#. Description of the 'Edit Filters' (Button) field in DocType 'Enabled
+#. DocType'
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+msgid "Optional: create PDF only if the submitted document matches these filters."
+msgstr ""
+
 #. Name of a DocType
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "PDF on Submit Settings"
 msgstr ""
 
 #. Label of a Link field in DocType 'Enabled DocType'
-#: pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+#: pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
 msgid "Print Format"
 msgstr ""
 
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js:22
+msgid "Set Filters"
+msgstr ""
+
 #. Name of a role
-#: pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+#: pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
 msgid "System Manager"
 msgstr ""
 

--- a/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+++ b/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
@@ -10,7 +10,8 @@
   "letter_head",
   "auto_name",
   "section_break_rset",
-  "edit_filters",
+  "filter_description",
+  "filter_area",
   "filters"
  ],
  "fields": [
@@ -43,26 +44,32 @@
    "options": "Letter Head"
   },
   {
+   "collapsible": 1,
    "fieldname": "section_break_rset",
-   "fieldtype": "Section Break"
-  },
-  {
-   "description": "Optional: create PDF only if the submitted document matches these filters.",
-   "fieldname": "edit_filters",
-   "fieldtype": "Button",
-   "label": "Edit Filters"
+   "fieldtype": "Section Break",
+   "label": "Filters"
   },
   {
    "fieldname": "filters",
    "fieldtype": "Code",
+   "hidden": 1,
    "label": "Filters",
    "options": "JSON",
    "read_only": 1
+  },
+  {
+   "fieldname": "filter_area",
+   "fieldtype": "HTML"
+  },
+  {
+   "fieldname": "filter_description",
+   "fieldtype": "HTML",
+   "options": "Optional: create PDF only if the submitted document matches these filters.<br><br>"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-02-07 19:24:29.460345",
+ "modified": "2025-02-08 01:03:04.756526",
  "modified_by": "Administrator",
  "module": "PDF on Submit",
  "name": "Enabled DocType",

--- a/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+++ b/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
@@ -8,7 +8,10 @@
   "document_type",
   "print_format",
   "letter_head",
-  "auto_name"
+  "auto_name",
+  "section_break_rset",
+  "edit_filters",
+  "filters"
  ],
  "fields": [
   {
@@ -38,11 +41,27 @@
    "in_list_view": 1,
    "label": "Letter Head",
    "options": "Letter Head"
+  },
+  {
+   "fieldname": "section_break_rset",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "edit_filters",
+   "fieldtype": "Button",
+   "label": "Edit Filters"
+  },
+  {
+   "fieldname": "filters",
+   "fieldtype": "Code",
+   "label": "Filters",
+   "options": "JSON",
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-11-23 19:10:49.683993",
+ "modified": "2025-02-07 18:27:42.976858",
  "modified_by": "Administrator",
  "module": "PDF on Submit",
  "name": "Enabled DocType",

--- a/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
+++ b/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.json
@@ -47,6 +47,7 @@
    "fieldtype": "Section Break"
   },
   {
+   "description": "Optional: create PDF only if the submitted document matches these filters.",
    "fieldname": "edit_filters",
    "fieldtype": "Button",
    "label": "Edit Filters"
@@ -61,7 +62,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-02-07 18:27:42.976858",
+ "modified": "2025-02-07 19:24:29.460345",
  "modified_by": "Administrator",
  "module": "PDF on Submit",
  "name": "Enabled DocType",

--- a/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.py
+++ b/pdf_on_submit/pdf_on_submit/doctype/enabled_doctype/enabled_doctype.py
@@ -1,7 +1,17 @@
 # Copyright (c) 2021, Raffael Meyer and contributors
 # For license information, please see license.txt
+import json
+
+import frappe
 from frappe.model.document import Document
+from frappe.utils.data import evaluate_filters
 
 
 class EnabledDocType(Document):
-	pass
+	def validate_filters(self):
+		if not self.filters:
+			return
+
+		filters = json.loads(self.filters)
+		dummy_doc = frappe.new_doc(self.document_type)
+		evaluate_filters(dummy_doc, filters)

--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
@@ -35,7 +35,7 @@ frappe.ui.form.on("Enabled DocType", {
 				);
 				dialog.hide(); // TODO: for some reason this also hides the child row
 			},
-			primary_action_label: "Set",
+			primary_action_label: __("Set Filters"),
 		});
 
 		frappe.model.with_doctype(row.document_type, () => {

--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
@@ -27,7 +27,12 @@ frappe.ui.form.on("Enabled DocType", {
 				},
 			],
 			primary_action: function () {
-				frappe.model.set_value(cdt, cdn, "filters", JSON.stringify(container.filter_group.get_filters(), null, 2));
+				frappe.model.set_value(
+					cdt,
+					cdn,
+					"filters",
+					JSON.stringify(container.filter_group.get_filters(), null, 2)
+				);
 				dialog.hide(); // TODO: for some reason this also hides the child row
 			},
 			primary_action_label: "Set",
@@ -43,5 +48,5 @@ frappe.ui.form.on("Enabled DocType", {
 
 			dialog.show();
 		});
-	}
+	},
 });

--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
@@ -11,42 +11,25 @@ frappe.ui.form.on("PDF on Submit Settings", {
 			};
 		});
 	},
-});
-
-frappe.ui.form.on("Enabled DocType", {
-	edit_filters(frm, cdt, cdn) {
-		const row = locals[cdt][cdn];
+	enabled_for_on_form_rendered(frm, dt, a, b, c) {
+		const row = frm.cur_grid.doc;
 		const filters = row.filters ? JSON.parse(row.filters) : [];
-		const container = {};
-		const dialog = new frappe.ui.Dialog({
-			title: __("Set Filters"),
-			fields: [
-				{
-					fieldtype: "HTML",
-					fieldname: "filter_area",
-				},
-			],
-			primary_action: function () {
-				frappe.model.set_value(
-					cdt,
-					cdn,
-					"filters",
-					JSON.stringify(container.filter_group.get_filters(), null, 2)
-				);
-				dialog.hide(); // TODO: for some reason this also hides the child row
-			},
-			primary_action_label: __("Set Filters"),
-		});
 
 		frappe.model.with_doctype(row.document_type, () => {
-			container.filter_group = new frappe.ui.FilterGroup({
-				parent: dialog.get_field("filter_area").$wrapper,
+			const filter_group = new frappe.ui.FilterGroup({
+				parent: frm.cur_grid.wrapper.find("[data-fieldname='filter_area']"),
 				doctype: row.document_type,
-				on_change: () => {},
+				on_change: () => {
+					frappe.model.set_value(
+						row.doctype,
+						row.name,
+						"filters",
+						JSON.stringify(filter_group.get_filters())
+					);
+				},
 			});
-			filters && container.filter_group.add_filters_to_filter_group(filters);
 
-			dialog.show();
+			filter_group.add_filters_to_filter_group(filters);
 		});
 	},
 });

--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
@@ -12,3 +12,36 @@ frappe.ui.form.on("PDF on Submit Settings", {
 		});
 	},
 });
+
+frappe.ui.form.on("Enabled DocType", {
+	edit_filters(frm, cdt, cdn) {
+		const row = locals[cdt][cdn];
+		const filters = row.filters ? JSON.parse(row.filters) : [];
+		const container = {};
+		const dialog = new frappe.ui.Dialog({
+			title: __("Set Filters"),
+			fields: [
+				{
+					fieldtype: "HTML",
+					fieldname: "filter_area",
+				},
+			],
+			primary_action: function () {
+				frappe.model.set_value(cdt, cdn, "filters", JSON.stringify(container.filter_group.get_filters(), null, 2));
+				dialog.hide(); // TODO: for some reason this also hides the child row
+			},
+			primary_action_label: "Set",
+		});
+
+		frappe.model.with_doctype(row.document_type, () => {
+			container.filter_group = new frappe.ui.FilterGroup({
+				parent: dialog.get_field("filter_area").$wrapper,
+				doctype: row.document_type,
+				on_change: () => {},
+			});
+			filters && container.filter_group.add_filters_to_filter_group(filters);
+
+			dialog.show();
+		});
+	}
+});

--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.py
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.py
@@ -1,7 +1,19 @@
 # Copyright (c) 2019, Raffael Meyer and contributors
 # For license information, please see license.txt
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class PDFonSubmitSettings(Document):
-	pass
+	def validate(self):
+		for enabled_doctype in self.enabled_for:
+			try:
+				enabled_doctype.validate_filters()
+			except Exception as e:
+				frappe.clear_messages()
+				frappe.throw(
+					_("Row #{0}: invalid filters for <b>{1}</b>: {2}").format(
+						enabled_doctype.idx, enabled_doctype.document_type, e
+					)
+				)


### PR DESCRIPTION
Allow setting filters for each enabled doctype.
![Bildschirmfoto 2025-02-09 um 19 04 42](https://github.com/user-attachments/assets/9e5beba0-417c-468c-81a4-09f29a2ac8bd)

The PDF gets created only, if the submitted document matches the filters.

Partly depends on https://github.com/frappe/frappe/pull/31190

Ref: TWI, IBT