### PR TITLE
fix(PDF on Submit Settings): UX improvements

### DIFF
--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
@@ -22,11 +22,7 @@ frappe.ui.form.on("PDF on Submit Settings", {
 	enabled_for_on_form_rendered(frm) {
 		const row = frm.cur_grid.doc;
 		const parent = frm.cur_grid.wrapper.find("[data-fieldname='filter_area']");
-
-		if (!row.document_type) {
-			parent.empty();
-			return;
-		}
+		parent.empty();
 
 		const filters = row.filters ? JSON.parse(row.filters) : [];
 

--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
@@ -24,7 +24,7 @@ frappe.ui.form.on("PDF on Submit Settings", {
 		const parent = frm.cur_grid.wrapper.find("[data-fieldname='filter_area']");
 		parent.empty();
 
-		const filters = row.filters ? JSON.parse(row.filters) : [];
+		const filters = row.filters && row.filters !== "[]" ? JSON.parse(row.filters) : [];
 
 		frappe.model.with_doctype(row.document_type, () => {
 			const filter_group = new frappe.ui.FilterGroup({

--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
@@ -10,6 +10,14 @@ frappe.ui.form.on("PDF on Submit Settings", {
 				},
 			};
 		});
+
+		frm.set_query("document_type", "enabled_for", function (doc, cdt, cdn) {
+			return {
+				filters: {
+					is_submittable: 1,
+				},
+			};
+		});
 	},
 	enabled_for_on_form_rendered(frm, dt, a, b, c) {
 		const row = frm.cur_grid.doc;

--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
@@ -19,13 +19,20 @@ frappe.ui.form.on("PDF on Submit Settings", {
 			};
 		});
 	},
-	enabled_for_on_form_rendered(frm, dt, a, b, c) {
+	enabled_for_on_form_rendered(frm) {
 		const row = frm.cur_grid.doc;
+		const parent = frm.cur_grid.wrapper.find("[data-fieldname='filter_area']");
+
+		if (!row.document_type) {
+			parent.empty();
+			return;
+		}
+
 		const filters = row.filters ? JSON.parse(row.filters) : [];
 
 		frappe.model.with_doctype(row.document_type, () => {
 			const filter_group = new frappe.ui.FilterGroup({
-				parent: frm.cur_grid.wrapper.find("[data-fieldname='filter_area']"),
+				parent: parent,
 				doctype: row.document_type,
 				on_change: () => {
 					frappe.model.set_value(
@@ -39,5 +46,16 @@ frappe.ui.form.on("PDF on Submit Settings", {
 
 			filter_group.add_filters_to_filter_group(filters);
 		});
+	},
+});
+
+frappe.ui.form.on("Enabled DocType", {
+	document_type(frm, cdt, cdn) {
+		const row = locals[cdt][cdn];
+		frappe.model.set_value(row.doctype, row.name, "filters", "[]");
+		frappe.model.set_value(row.doctype, row.name, "print_format", "");
+		if (frm.cur_grid) {
+			frm.events.enabled_for_on_form_rendered(frm);
+		}
 	},
 });

--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.js
@@ -49,7 +49,17 @@ frappe.ui.form.on("Enabled DocType", {
 	document_type(frm, cdt, cdn) {
 		const row = locals[cdt][cdn];
 		frappe.model.set_value(row.doctype, row.name, "filters", "[]");
-		frappe.model.set_value(row.doctype, row.name, "print_format", "");
+
+		if (row.print_format) {
+			// Check if the print format is valid for the document type
+			// If not, set the print format to an empty string
+			frappe.db.get_value("Print Format", row.print_format, "doc_type").then((r) => {
+				if (r.message.doc_type !== row.document_type) {
+					frappe.model.set_value(row.doctype, row.name, "print_format", "");
+				}
+			});
+		}
+
 		if (frm.cur_grid) {
 			frm.events.enabled_for_on_form_rendered(frm);
 		}


### PR DESCRIPTION
Resolves UX issues that went unnoticed in #60

- Only allow to select submittable doctypes
- Handle edge cases for filters (not very edge, in hindsight 😄 )
	- Open a row without a _Document Type_ -> do not initialize filter UI
	- Change the _Document Type_ of a closed row -> reset filters and print format, do not initialize filter UI
	- Change the _Document Type_ of an opened row -> reset filters and print format, reinitialize filter UI