### PR TITLE
feat: Make background job timeout configurable (IBT-86)

### DIFF
--- a/pdf_on_submit/attach_pdf.py
+++ b/pdf_on_submit/attach_pdf.py
@@ -25,6 +25,8 @@ def attach_pdf(doc, event=None):
 
 
 def process_enabled_doctype(doc, settings, in_background):
+	DEFAULT_TIMEOUT = 30 
+	
 	if settings.filters:
 		filters = json.loads(settings.filters)
 		if filters:
@@ -54,7 +56,7 @@ def process_enabled_doctype(doc, settings, in_background):
 
 	frappe.enqueue(
 		method=execute,
-		timeout=30,
+		timeout= frappe.get_single_value("PDF on Submit Settings", "timeout") or DEFAULT_TIMEOUT,
 		now=bool(
 			not in_background
 			or frappe.flags.in_test

--- a/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
+++ b/pdf_on_submit/pdf_on_submit/doctype/pdf_on_submit_settings/pdf_on_submit_settings.json
@@ -8,7 +8,8 @@
   "section_break_1",
   "enabled_for",
   "section_break_8",
-  "create_pdf_in_background"
+  "create_pdf_in_background",
+  "timeout_seconds"
  ],
  "fields": [
   {
@@ -31,12 +32,18 @@
    "fieldtype": "Table",
    "label": "Enabled For",
    "options": "Enabled DocType"
+  },
+  {
+   "depends_on": "eval:doc.create_pdf_in_background",
+   "fieldname": "timeout_seconds",
+   "fieldtype": "Int",
+   "label": "Timeout (in Seconds)"
   }
  ],
  "icon": "octicon octicon-file-pdf",
  "issingle": 1,
  "links": [],
- "modified": "2021-01-13 15:44:40.308041",
+ "modified": "2025-08-26 09:52:13.765753",
  "modified_by": "Administrator",
  "module": "PDF on Submit",
  "name": "PDF on Submit Settings",
@@ -62,7 +69,9 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
Implement configurable timeout
add function get_timeout_config() with fallback of 30 sekonds, if no timeout is set.
add text field with int in pdf_on_submit settings

Resolves: #69 