### PR TITLE
feat: split lists in Text Editor HTML

### DIFF
--- a/pdf_on_submit/quill.py
+++ b/pdf_on_submit/quill.py
@@ -1,10 +1,17 @@
 from bs4 import BeautifulSoup
+from bs4.element import NavigableString, Tag
+
+
+LIST_TAGS = {"ol", "ul"}
 
 
 def split_quill(html: str) -> list[str]:
-	"""Split a Text Editor HTML string into a list of HTML strings, each representing a direct child of the editor div.
+	"""Split a Text Editor HTML string into printable HTML fragments.
 
-	This is useful for breaking text-editor content into separate rows in a print format."""
+	Top-level Quill blocks are returned separately so print formats can render them
+	as individual table rows. Lists are split further by item because wkhtmltopdf
+	handles page breaks between table rows more reliably than page breaks inside
+	long table cells."""
 	soup = BeautifulSoup(html, "html.parser")
 	nested_divs = soup.find_all("div", recursive=False)
 
@@ -13,7 +20,99 @@ def split_quill(html: str) -> list[str]:
 		return [html]
 
 	div = nested_divs[0]
-	if div.has_attr("class") and "ql-editor" in div["class"]:
-		return [f'<div class="ql-editor">{str(child)}</div>' for child in div.children]
-	else:
-		return [str(child) for child in div.children]
+	fragments = _split_children(div)
+
+	if _is_quill_editor(div):
+		return [_wrap_in_editor(div, fragment) for fragment in fragments]
+
+	return fragments
+
+
+def _split_children(parent: Tag) -> list[str]:
+	fragments = []
+
+	for child in parent.children:
+		if _is_blank_text(child):
+			continue
+
+		if isinstance(child, Tag) and child.name in LIST_TAGS:
+			fragments.extend(_split_list(child))
+		else:
+			fragments.append(str(child))
+
+	return fragments
+
+
+def _split_list(list_tag: Tag) -> list[str]:
+	list_items = [child for child in list_tag.children if isinstance(child, Tag) and child.name == "li"]
+	if not list_items:
+		return [str(list_tag)]
+
+	fragments = []
+	ordered_counters = [0] * 10
+
+	for item in list_items:
+		fragment = _new_tag_like(list_tag)
+
+		if _is_ordered_list_item(list_tag, item):
+			indent = _get_quill_indent(item)
+			ordered_counters[indent] += 1
+			ordered_counters[indent + 1 :] = [0] * (len(ordered_counters) - indent - 1)
+			_set_ordered_list_start(fragment, indent, ordered_counters[indent])
+
+		fragment.append(BeautifulSoup(str(item), "html.parser").find("li"))
+		fragments.append(str(fragment))
+
+	return fragments
+
+
+def _is_quill_editor(tag: Tag) -> bool:
+	return "ql-editor" in tag.get("class", [])
+
+
+def _is_blank_text(element: Tag | NavigableString) -> bool:
+	return isinstance(element, NavigableString) and not element.strip()
+
+
+def _new_tag_like(tag: Tag) -> Tag:
+	soup = BeautifulSoup("", "html.parser")
+	new_tag = soup.new_tag(tag.name)
+	new_tag.attrs = dict(tag.attrs)
+	return new_tag
+
+
+def _wrap_in_editor(editor_tag: Tag, fragment: str) -> str:
+	soup = BeautifulSoup("", "html.parser")
+	editor = soup.new_tag("div")
+	editor.attrs = dict(editor_tag.attrs)
+	fragment_soup = BeautifulSoup(fragment, "html.parser")
+
+	for child in list(fragment_soup.contents):
+		editor.append(child)
+
+	return str(editor)
+
+
+def _is_ordered_list_item(list_tag: Tag, item: Tag) -> bool:
+	data_list = item.get("data-list")
+	if data_list:
+		return data_list == "ordered"
+
+	return list_tag.name == "ol"
+
+
+def _get_quill_indent(item: Tag) -> int:
+	for class_name in item.get("class", []):
+		if class_name.startswith("ql-indent-"):
+			return int(class_name.removeprefix("ql-indent-"))
+
+	return 0
+
+
+def _set_ordered_list_start(list_tag: Tag, indent: int, number: int) -> None:
+	if indent == 0 and list_tag.name == "ol":
+		list_tag["start"] = str(number)
+
+	style = list_tag.get("style", "").rstrip()
+	counter_reset = f"counter-reset: list-{indent} {number - 1};"
+	list_tag["style"] = f"{style.rstrip(';')}; {counter_reset}" if style else counter_reset

--- a/pdf_on_submit/quill.py
+++ b/pdf_on_submit/quill.py
@@ -1,3 +1,5 @@
+import copy
+
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 
@@ -77,14 +79,14 @@ def _is_blank_text(element: Tag | NavigableString) -> bool:
 def _new_tag_like(tag: Tag) -> Tag:
 	soup = BeautifulSoup("", "html.parser")
 	new_tag = soup.new_tag(tag.name)
-	new_tag.attrs = dict(tag.attrs)
+	new_tag.attrs = copy.deepcopy(tag.attrs)
 	return new_tag
 
 
 def _wrap_in_editor(editor_tag: Tag, fragment: str) -> str:
 	soup = BeautifulSoup("", "html.parser")
 	editor = soup.new_tag("div")
-	editor.attrs = dict(editor_tag.attrs)
+	editor.attrs = copy.deepcopy(editor_tag.attrs)
 	fragment_soup = BeautifulSoup(fragment, "html.parser")
 
 	for child in list(fragment_soup.contents):

--- a/pdf_on_submit/quill.py
+++ b/pdf_on_submit/quill.py
@@ -106,7 +106,10 @@ def _is_ordered_list_item(list_tag: Tag, item: Tag) -> bool:
 def _get_quill_indent(item: Tag) -> int:
 	for class_name in item.get("class", []):
 		if class_name.startswith("ql-indent-"):
-			return int(class_name.removeprefix("ql-indent-"))
+			try:
+				return int(class_name.removeprefix("ql-indent-"))
+			except ValueError:
+				pass
 
 	return 0
 

--- a/pdf_on_submit/tests/test_quill.py
+++ b/pdf_on_submit/tests/test_quill.py
@@ -46,3 +46,23 @@ class TestSplitQuill(unittest.TestCase):
 
 		self.assertEqual(second_list.get("start"), "2")
 		self.assertEqual(second_list.get("style"), "counter-reset: list-0 1;")
+
+	def test_split_quill_resets_nested_ordered_list_numbers(self):
+		html = """<div class="ql-editor">
+<ol>
+<li data-list="ordered"><span class="ql-ui" contenteditable="false"></span>one</li>
+<li class="ql-indent-1" data-list="ordered"><span class="ql-ui" contenteditable="false"></span>one-a</li>
+<li class="ql-indent-1" data-list="ordered"><span class="ql-ui" contenteditable="false"></span>one-b</li>
+<li data-list="ordered"><span class="ql-ui" contenteditable="false"></span>two</li>
+<li class="ql-indent-1" data-list="ordered"><span class="ql-ui" contenteditable="false"></span>two-a</li>
+</ol>
+</div>"""
+
+		fragments = split_quill(html)
+		first_nested_list = BeautifulSoup(fragments[1], "html.parser").find("ol")
+		second_nested_list = BeautifulSoup(fragments[2], "html.parser").find("ol")
+		reset_nested_list = BeautifulSoup(fragments[4], "html.parser").find("ol")
+
+		self.assertEqual(first_nested_list.get("style"), "counter-reset: list-1 0;")
+		self.assertEqual(second_nested_list.get("style"), "counter-reset: list-1 1;")
+		self.assertEqual(reset_nested_list.get("style"), "counter-reset: list-1 0;")

--- a/pdf_on_submit/tests/test_quill.py
+++ b/pdf_on_submit/tests/test_quill.py
@@ -1,0 +1,48 @@
+import unittest
+
+from bs4 import BeautifulSoup
+
+from pdf_on_submit.quill import split_quill
+
+
+class TestSplitQuill(unittest.TestCase):
+	def test_split_quill_splits_top_level_blocks(self):
+		html = '<div class="ql-editor"><p>One</p><p>Two</p></div>'
+
+		self.assertEqual(
+			split_quill(html),
+			[
+				'<div class="ql-editor"><p>One</p></div>',
+				'<div class="ql-editor"><p>Two</p></div>',
+			],
+		)
+
+	def test_split_quill_splits_list_items(self):
+		html = """<div class="ql-editor read-mode">
+<ol>
+<li data-list="bullet"><span class="ql-ui" contenteditable="false"></span>a</li>
+<li data-list="bullet"><span class="ql-ui" contenteditable="false"></span>b</li>
+</ol>
+</div>"""
+
+		self.assertEqual(
+			split_quill(html),
+			[
+				'<div class="ql-editor read-mode"><ol><li data-list="bullet"><span class="ql-ui" contenteditable="false"></span>a</li></ol></div>',
+				'<div class="ql-editor read-mode"><ol><li data-list="bullet"><span class="ql-ui" contenteditable="false"></span>b</li></ol></div>',
+			],
+		)
+
+	def test_split_quill_preserves_ordered_list_numbers(self):
+		html = """<div class="ql-editor">
+<ol>
+<li data-list="ordered"><span class="ql-ui" contenteditable="false"></span>one</li>
+<li data-list="ordered"><span class="ql-ui" contenteditable="false"></span>two</li>
+</ol>
+</div>"""
+
+		fragments = split_quill(html)
+		second_list = BeautifulSoup(fragments[1], "html.parser").find("ol")
+
+		self.assertEqual(second_list.get("start"), "2")
+		self.assertEqual(second_list.get("style"), "counter-reset: list-0 1;")


### PR DESCRIPTION
## Summary
- Improve `split_quill` so long Quill lists are split into separate printable fragments per list item.
- Preserve Quill editor wrapper/classes and ordered-list numbering when fragments are rendered as separate table rows.
- Add regression tests for block splitting, bullet lists, and ordered list numbering.

## Test Plan
- `env/bin/python -m unittest pdf_on_submit.tests.test_quill`
- Manually verified the provided long-list HTML is split into one fragment per list item.
- Tested with real invoice: correct page breaks and counters on ol

Ref: VOI